### PR TITLE
Update S04E02LiveQandA.md

### DIFF
--- a/qanda/S04E02LiveQandA.md
+++ b/qanda/S04E02LiveQandA.md
@@ -103,6 +103,11 @@ Not quite - but they can work together. Ingress controller routes traffic based 
 ## how does it has 146% of CPU? did it add more CPU itself?
 When you see a CPU usage figure like 146% in the context of horizontal pod scaling in Kubernetes, it typically indicates that the CPU usage has exceeded the capacity of one CPU core.
 
+## How long does it take for AKS to stand up an additional pod? Does the time depends on the size of CPU/Memory allocation/image size?
+The time to stand up an additional pod in AKS depends on node availability, image size, and resource requirements. Larger container images and the need for additional nodes due to resource constraints can significantly increase startup time, ranging from a few seconds to several minutes. Node autoscaling, if required, typically adds 3 to 7 minutes to the process.
+
+
+
 
 
 


### PR DESCRIPTION
This pull request includes a small addition to the `qanda/S04E02LiveQandA.md` file. The change adds a new FAQ entry about the time it takes for Azure Kubernetes Service (AKS) to stand up an additional pod.

* [`qanda/S04E02LiveQandA.md`](diffhunk://#diff-1920ba2c405a601c5681ab91682b7eafbc604c857f7817ae350f255a86a387b9R106-R110): Added a new FAQ entry explaining that the time to stand up an additional pod in AKS depends on node availability, image size, and resource requirements, and that node autoscaling can add 3 to 7 minutes to the process.