### PR TITLE
Revise episode title to reflect AI platform engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Register to watch the broadcast: [Live Broadcast](https://developer.microsoft.co
 
 ![Platform Egineering](https://github.com/ANZAzureDevs/New-Breakpoint/blob/c087b113467bf288dc3c2b6cf376cff90e02a26e/media/1756422002021.jpg)
 
-## 2025-09-11: New Breakpoint S5 Ep 3: Agents with Purpose - GenAI Meets LEGO
+## 2025-09-11: New Breakpoint S5 Ep 3: Platform Engineering in the age of AI
 
 Kubernetes is the new normal—but what’s next?
 


### PR DESCRIPTION
This pull request updates the episode title in the `README.md` to better reflect the focus on platform engineering and AI.

* Documentation update:
  * Changed the episode title in `README.md` from "Agents with Purpose - GenAI Meets LEGO" to "Platform Engineering in the age of AI" to clarify the episode's theme.Updated episode title and description for clarity.