### PR TITLE
Add resource links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,11 @@ Join host Michelle Sandford as she welcomes Randy Bias and Bharath Nallapeta fro
 📍 Add to your calendar and join us live! https://msft.it/6042sw2I4
 
 ### Episode Resources:
+
+[Microsoft Learn Platform Engineering Resources](https://learn.microsoft.com/en-us/platform-engineering/)
+[Foundations of Platform Engineering](https://learn.microsoft.com/en-us/training/modules/foundations-platform-engineering/?source=recommendations)
+[DevOps Engineers Training Plan](https://learn.microsoft.com/en-us/plans/6ey7h68p2zk3j2?source=docs)
+[k0rdent GitHub Repo](https://github.com/k0rdent)
+[KCM](https://github.com/k0rdent/kcm)
+[k0rdent Catalogue](https://github.com/k0rdent/catalog) 
+[k0rdent Webpage](https://k0rdent.io/)


### PR DESCRIPTION
This pull request adds several new resource links to the episode resources section in the `README.md` file, providing viewers with helpful references related to platform engineering and the k0rdent project.

New resource links added:

* Added links to Microsoft Learn resources covering platform engineering, foundational training, and DevOps engineer training plans.
* Included direct links to the k0rdent GitHub repository, KCM project, k0rdent catalogue, and the k0rdent official webpage.Added links to various resources related to platform engineering and DevOps training.